### PR TITLE
Add mono {object} spaces option to braces_spacing rule

### DIFF
--- a/coffeelint.json
+++ b/coffeelint.json
@@ -37,7 +37,8 @@
     },
     "braces_spacing": {
         "level": "error",
-        "spaces": 1
+        "spaces": 1,
+        "mono_object_spaces": 1
     },
     "eol_last": {
         "level": "error"

--- a/src/rules/braces_spacing.coffee
+++ b/src/rules/braces_spacing.coffee
@@ -11,6 +11,8 @@ module.exports = class BracesSpacing
             curly braces. The spacing amount is specified by "spaces".
             The spacing amount for empty objects is specified by
             "empty_object_spaces".
+            The spacing amount for objects containing a single item is
+            specified by "mono_object_spaces".
 
             <pre><code>
             # Spaces is 0
@@ -35,10 +37,20 @@ module.exports = class BracesSpacing
             # Empty Object Spaces is 1
             {}         # Bad
             { }        # Good
+
+            # Mono Object Spaces is 0
+            {a}        # Good
+            { a }      # Bad
+
+            # Mono Object Spaces is 1
+            {a}        # Bad
+            { a }      # Good
             </code></pre>
 
             This rule is disabled by default.
             '''
+
+    constructor: -> @rule.mono_object_spaces = @rule.spaces
 
     tokens: ['{', '}']
 
@@ -50,30 +62,41 @@ module.exports = class BracesSpacing
         loop
             totalDifference += difference
             nearestToken = tokenApi.peek(totalDifference)
-            continue if nearestToken[0] is 'OUTDENT' or nearestToken.generated?
+            continue if nearestToken?[0] is 'OUTDENT' or nearestToken?.generated?
             return nearestToken
 
     tokensOnSameLine: (firstToken, secondToken) ->
         firstToken[2].first_line is secondToken[2].first_line
 
-    getExpectedSpaces: (tokenApi, firstToken, secondToken) ->
+    tokenSetsMatch: (a, b) -> JSON.stringify(a) is JSON.stringify b
+
+    getExpectedSpaces: (tokenApi, tokens) ->
         config = tokenApi.config[@rule.name]
-        if firstToken[0] is '{' and secondToken[0] is '}'
+        mono = [ 'IDENTIFIER', @tokens...]
+        tokens = tokens
+            .map (token) -> token?[0]
+            .filter (token) -> token in mono
+
+        if @tokenSetsMatch tokens, @tokens
             config.empty_object_spaces ? config.spaces
+        else if @tokenSetsMatch mono, tokens.sort()
+            config.mono_object_spaces ? config.spaces
         else
             config.spaces
 
     lintToken: (token, tokenApi) ->
         return null if token.generated
 
-        [firstToken, secondToken] = if token[0] is '{'
-            [token, @findNearestToken(token, tokenApi, 1)]
+        [firstToken, secondToken] = tokens = if token[0] is '{'
+            [token, @findNearestToken(token, tokenApi, 1),
+                    @findNearestToken(token, tokenApi, 2)]
         else
-            [@findNearestToken(token, tokenApi, -1), token]
+            [@findNearestToken(token, tokenApi, -1), token,
+             @findNearestToken(token, tokenApi, -2)]
 
         return null unless @tokensOnSameLine firstToken, secondToken
 
-        expected = @getExpectedSpaces tokenApi, firstToken, secondToken
+        expected = @getExpectedSpaces tokenApi, tokens
         actual = @distanceBetweenTokens firstToken, secondToken
 
         if actual is expected

--- a/test/test_braces_spacing.coffee
+++ b/test/test_braces_spacing.coffee
@@ -4,6 +4,10 @@ assert = require 'assert'
 coffeelint = require path.join('..', 'lib', 'coffeelint')
 
 sources =
+    monoObject:
+        noSpaces: '{foo}'
+        oneSpace: '{ foo }'
+        twoSpaces: '{  foo  }'
     emptyObject:
         noSpaces: '{}'
         oneSpace: '{ }'
@@ -49,10 +53,14 @@ sources =
 configs =
     oneEmptyObjectSpace:
         braces_spacing: { level: 'error', empty_object_spaces: 1 }
+    oneMonoObjectSpace:
+        braces_spacing: { level: 'error', mono_object_spaces: 1 }
     oneSpace:
         braces_spacing: { level: 'error', spaces: 1 }
     zeroEmptyObjectSpaces:
         braces_spacing: { level: 'error', empty_object_spaces: 0 }
+    zeroMonoObjectSpaces:
+        braces_spacing: { level: 'error', mono_object_spaces: 0 }
     zeroSpaces:
         braces_spacing: { level: 'error', spaces: 0 }
 
@@ -211,6 +219,43 @@ vows.describe(RULE).addBatch({
                        configs.oneEmptyObjectSpace,
                        ['There should be 1 space inside "{"',
                         'There should be 1 space inside "}"'])
+
+
+    'enabled with mono object spaces set to 0':
+        'no spaces inside both braces':
+            shouldPass(sources.monoObject.noSpaces,
+                       configs.zeroMonoObjectSpaces)
+
+        'one space inside on both braces':
+            shouldFail(sources.monoObject.oneSpace,
+                       configs.zeroMonoObjectSpaces,
+                       ['There should be 0 spaces inside "{"',
+                        'There should be 0 spaces inside "}"'])
+
+        'two spaces inside on both braces':
+            shouldFail(sources.monoObject.twoSpaces,
+                       configs.zeroMonoObjectSpaces,
+                       ['There should be 0 spaces inside "{"',
+                        'There should be 0 spaces inside "}"'])
+
+
+    'enabled with mono object spaces set to 1':
+        'no spaces inside both braces':
+            shouldFail(sources.monoObject.noSpaces,
+                       configs.oneMonoObjectSpace,
+                       ['There should be 1 space inside "{"',
+                        'There should be 1 space inside "}"'])
+
+        'one space inside on both braces':
+            shouldPass(sources.monoObject.oneSpace,
+                       configs.oneMonoObjectSpace)
+
+        'two spaces inside on both braces':
+            shouldFail(sources.monoObject.twoSpaces,
+                       configs.oneMonoObjectSpace,
+                       ['There should be 1 space inside "{"',
+                        'There should be 1 space inside "}"'])
+
 
     'handles generated tokens being on the same line (in outputted code)':
         'no spaces inside both braces':


### PR DESCRIPTION
@aminland This option added to the `braces_spacing` rule allows linting of spaces between braces on "mono" `Object`s, (those that contain only a _single identifier_…) For example `{foo}`, but not `{ foo: bar }`, or `{ foo, bar }`, and also includes `import` statements (e.g `import {foo} from 'bar'`).