### PR TITLE
Add ignore elision option to spacing_after_comma rule

### DIFF
--- a/src/rules/spacing_after_comma.coffee
+++ b/src/rules/spacing_after_comma.coffee
@@ -2,9 +2,17 @@ module.exports = class SpacingAfterComma
     rule:
         name: 'spacing_after_comma'
         level: 'ignore'
+        ignore_elision: false
         message: 'a space is required after commas'
         description: '''
             This rule checks to make sure you have a space after commas.
+            Consecutive commas are allowed when skipping array elements
+            if "ignore_elision" is true.
+
+            <pre><code>
+            # ignore_elision: true
+            [,, c,, e, f] = [1, 2, 3, 4, 5, 6]
+            </code></pre>
             '''
 
     tokens: [',', 'REGEX_START', 'REGEX_END']
@@ -21,6 +29,9 @@ module.exports = class SpacingAfterComma
         if type is 'REGEX_END'
             @inRegex = false
             return
+
+        { ignore_elision } = tokenApi.config[@rule.name]
+        return null if ignore_elision and ',' in tokenApi.peek(1)
 
         unless token.spaced or token.newLine or @isGenerated(token, tokenApi) or
                 @isRegexFlag(token, tokenApi)

--- a/test/test_spacing_after_comma.coffee
+++ b/test/test_spacing_after_comma.coffee
@@ -82,4 +82,17 @@ vows.describe(RULE).addBatch({
             errors = coffeelint.lint(source, config)
             assert.lengthOf(errors, 3)
 
+    'Allow consecutive commas when skipping array elements':
+        topic:
+            '''
+            [,, c,, e, f] = [1, 2, 3, 4, 5, 6]
+            '''
+
+        'should not error': (source) ->
+            config = spacing_after_comma:
+                level: 'error'
+                ignore_elision: true
+            errors = coffeelint.lint(source, config)
+            assert.equal(errors.length, 0)
+
 }).export(module)


### PR DESCRIPTION
@aminland This option added to the `spacing_after_comma` rule allows it to ignore consecutive commas when skipping array elements. For example `[,, c,, e, f] = [1, 2, 3, 4, 5, 6]`. This is known as _[elision](https://github.com/jashkenas/coffeescript/pull/4796)_.