### PR TITLE
fix double quotes in csx

### DIFF
--- a/test/test_no_unnecessary_double_quotes.coffee
+++ b/test/test_no_unnecessary_double_quotes.coffee
@@ -170,4 +170,17 @@ vows.describe(RULE).addBatch({
             errors = coffeelint.lint(source, config)
             assert.lengthOf(errors, 0)
 
+    'Test csx #2':
+        topic:
+            '''
+            class Example
+              hello: ->
+                <Hello></Hello>
+            '''
+
+        'should not generate an error': (source) ->
+            config = { no_unnecessary_double_quotes: { level: 'error' } }
+            errors = coffeelint.lint(source, config)
+            assert.lengthOf(errors, 0)
+
 }).export(module)


### PR DESCRIPTION
CSX generates double quotes in it's function calls. This PR prevents them as being considered in no_unnecessary_double_quotes

fixes #2 